### PR TITLE
Remove default keypress from interactor styles

### DIFF
--- a/client/src/vtk/interaction/interactor-style-ninjato-3d/interactor-style-ninjato-3d.js
+++ b/client/src/vtk/interaction/interactor-style-ninjato-3d/interactor-style-ninjato-3d.js
@@ -20,6 +20,10 @@ function vtkInteractorStyleNinjato3D(publicAPI, model) {
   model.classHierarchy.push('vtkInteractorStyleNinjato3D');
 
   // Public API methods
+  //----------------------------------------------------------------------------
+  publicAPI.handleKeyPress = () => {}
+
+  //----------------------------------------------------------------------------
   publicAPI.handleMouseMove = (callData) => {
     const pos = callData.position;
     const renderer = callData.pokedRenderer;

--- a/client/src/vtk/interaction/interactor-style-ninjato-slice/interactor-style-ninjato-slice.js
+++ b/client/src/vtk/interaction/interactor-style-ninjato-slice/interactor-style-ninjato-slice.js
@@ -20,6 +20,10 @@ function vtkInteractorStyleNinjatoSlice(publicAPI, model) {
   model.classHierarchy.push('vtkInteractorStyleNinjatoSlice');
 
   // Public API methods
+  //----------------------------------------------------------------------------
+  publicAPI.handleKeyPress = () => {}
+
+  //----------------------------------------------------------------------------
   publicAPI.handleMouseMove = (callData) => {
     const pos = callData.position;
     const renderer = callData.pokedRenderer;


### PR DESCRIPTION
### Bugfixes
- Remove default key presses, e.g. 'w' switching to wireframe