### PR TITLE
fix the volume disappearing issue after verifying

### DIFF
--- a/girder/plugins/ninjato_api/girder_ninjato_api/utils.py
+++ b/girder/plugins/ninjato_api/girder_ninjato_api/utils.py
@@ -301,10 +301,6 @@ def update_assignment_in_whole_item(whole_item, assign_item_id, mask_file_name=N
             assetstore_id = item_file['assetstoreId']
             # remove the original file and create new file using updated TIFF mask
             File().remove(item_file)
-            # for some reason, the file on disk is not really removed, so double check to make
-            # sure it is deleted
-            if os.path.exists(whole_path):
-                os.remove(whole_path)
             save_file(assetstore_id, whole_item, output_path, User().getAdmins()[0], file_name)
             return
 


### PR DESCRIPTION
This only happens when two whole volumes share the same file on disk managed by girder and mongodb.