### PR TITLE
Do not call handleMouseWheel on handleStartMouseWheel

### DIFF
--- a/client/src/vtk/interaction/interactor-style-ninjato-slice/interactor-style-ninjato-slice.js
+++ b/client/src/vtk/interaction/interactor-style-ninjato-slice/interactor-style-ninjato-slice.js
@@ -143,7 +143,6 @@ function vtkInteractorStyleNinjatoSlice(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.handleStartMouseWheel = (callData) => {
-    publicAPI.handleMouseWheel(callData);
   };
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
To avoid handling twice for each event